### PR TITLE
feat: Update FRD documents for simplified user flow

### DIFF
--- a/resources/prd_tasks/04 favorites/04-favorites
+++ b/resources/prd_tasks/04 favorites/04-favorites
@@ -14,8 +14,7 @@ Allow users quick access to saved Surah/Ayah ranges for memorization and playbac
 ### 2. Favorites List
 * Each item displays:
   * Surah number + Ayah range
-  * Reciter & Translation language
-  * **Play button** – opens Media Player with stored preferences
+  * **Play button** – opens Media Player with **default settings**
   * **Delete (trash icon)** – removes favorite after confirmation
 
 #### Delete Confirmation Dialog
@@ -24,36 +23,36 @@ Allow users quick access to saved Surah/Ayah ranges for memorization and playbac
 * Buttons: **Yes (Primary)** / **Cancel (Secondary)**
 
 ### 3. Floating Action Button (FAB)
-* Icon: **“+”**
-* Action: Opens **Audio Configuration Modal** (`lib>screens>audio_config_modal.dart`)
-* Modal includes **“Save to Favorites”** option
+* Icon: **"+"**
+* Action: Opens **Range Picker Bottom Sheet** (`lib>screens>range_picker_bottom_sheet.dart`)
+* Bottom sheet includes **Surah selection** and **Ayah range picker** only
 * On save → new entry is added to Favorites list
 
 ---
 
 ## Example Entries
-* Surah 2: Ayah 1–7 (Mishary, English)
-* Surah 36: Ayah 1–12 (Abdul Rahman, Tamil)
+* Surah 2: Ayah 1–7
+* Surah 36: Ayah 1–12
 
 ---
 
 ## Behavior
 1. **Favorites List**
    * Loads persisted favorite entries on screen load
-   * Displays Surah/Ayah range + Reciter + Translation
+   * Displays Surah/Ayah range only
    * Each entry has Play + Delete actions
 
 2. **Play Button** <span style="color: red;background-color: yellow">*(check player filename. required/not?)*</span> 
-   * Opens **Media Player** (`lib>screens>media_player.dart`) with stored settings
+   * Opens **Media Player** (`lib>screens>media_player.dart`) with **default settings**
 
 3. **Delete Action**
    * Requires confirmation dialog before removal
 
 4. **Add Action (FAB +)**
-   * Opens Audio Config Modal
-   * User selects preferences → clicks *Save to Favorites*
+   * Opens **Range Picker Bottom Sheet**
+   * User selects Surah and Ayah range → clicks *Save to Favorites*
    * Entry saved and shown in Favorites list
-   * After save, a succedd message should be displayed for 3s and then the message should be closed. clicking on the message does nothing.
+   * After save, a success message should be displayed for 3s and then the message should be closed. clicking on the message does nothing.
 
 
 ---
@@ -75,8 +74,9 @@ Allow users quick access to saved Surah/Ayah ranges for memorization and playbac
 ## Developer Notes <span style="color: red;background-color: yellow">*(check filenames. required/not?)*</span> 
 * Implement Favorites Screen in: `lib>screens>favorites.dart`
 * Integrate with:
-  * **Audio Config Modal** (`lib>screens>audio_config_modal.dart`)
+  * **Range Picker Bottom Sheet** (`lib>screens>range_picker_bottom_sheet.dart`)
   * **Media Player** (`lib>screens>media_player.dart`)
   * **Theme file** (`lib>utils>theme.dart`)
 * Persistence: store favorites locally (e.g., SharedPreferences or local DB)
+* Favorites only store Surah/Ayah ranges - no reciter/translation preferences
 

--- a/resources/prd_tasks/05 settings/05-settings
+++ b/resources/prd_tasks/05 settings/05-settings
@@ -1,7 +1,7 @@
 ## Feature: Settings Screen (MVP - Light)
 
 ### Purpose
-Provide users with the ability to set default preferences, manage downloads, and view basic system information.
+Provide users with the ability to set **default preferences** for audio playback, manage downloads, and view basic system information. These defaults are used when starting new playback sessions.
 
 ---
 
@@ -10,13 +10,13 @@ Provide users with the ability to set default preferences, manage downloads, and
 ### 1. Default Preferences
 * **Arabic Reciter (Dropdown)**
   * Displays available reciters
-  * Stores user’s default reciter for playback
+  * Stores user's **default reciter** for all new playback sessions
 * **Translation (Dropdown: Language + Version)**
   * Displays supported languages and their versions
-  * Stores user’s default translation
+  * Stores user's **default translation** for all new playback sessions
 * **Playback Speed (Dropdown)**
   * Options: 0.5x, 1x (default), 1.25x, 1.5x, 2x
-  * Stores user’s default playback speed
+  * Stores user's **default playback speed** for all new playback sessions
 
 ### 2. Downloads Management
 * **Clear Downloads Button**
@@ -44,9 +44,13 @@ Provide users with the ability to set default preferences, manage downloads, and
 ## Behavior
 
 1. **Preferences**
-   * Persist user’s selected defaults locally
-   * Auto-apply defaults when playing any Surah/Ayah
-   * Dropdown changes update stored preferences immediately
+   * Persist user's selected **defaults** locally
+   * Auto-apply defaults when starting **new playback sessions**
+   * Dropdown changes update stored **default preferences** immediately
+   * These defaults are used when:
+     * Tapping a Surah from the Surah List
+     * Playing a Favorite
+     * Starting any new audio session
 
 2. **Cache Management**
    * Clear Cache → deletes audio files, temporary data
@@ -81,8 +85,10 @@ Provide users with the ability to set default preferences, manage downloads, and
 ## Developer Notes
 * Implement Settings Screen in: `lib>screens>settings.dart`
 * Integrations:
-  * **Preferences** – store using SharedPreferences / local DB
+  * **Default Preferences** – store using SharedPreferences / local DB
   * **Downloads** – integrate with existing download manager module (if available)
   * **App Version** – read from build info (`package_info_plus` in Flutter)
 * Confirmation dialogs should follow same design as Favorites delete dialog
+* **Important**: These are **default settings** that apply to new playback sessions only
+* Session-specific changes (via FAB Player settings) don't override these defaults
 


### PR DESCRIPTION
## Overview
This PR updates the Functional Requirements Documents (FRD) to reflect a simplified user flow for the Verse Flow app.

## Key Changes

### 🎯 Simplified User Journey
- **One-tap playback**: Users can now tap any Surah to immediately start playing with default settings
- **Session-specific customization**: Users can change reciter/translation during playback without affecting defaults
- **Streamlined favorites**: Favorites now only store Quran portions (Surah/Ayah ranges), not audio configurations

### 📋 Updated Documents

#### 1. Surah List Screen ()
- ✅ Direct play with default settings
- ✅ No configuration modal on Surah tap
- ✅ Immediate FAB Player launch

#### 2. FAB Player ()
- ✅ Added settings icon for session-specific changes
- ✅ Auto-launch when tapping Surahs
- ✅ Session-only settings (don't override defaults)

#### 3. Audio Configuration Modal ()
- ✅ Converted to Settings Overlay for FAB Player
- ✅ Removed range picker and Surah selection
- ✅ Focus on reciter/translation changes only

#### 4. Favorites Screen ()
- ✅ Simplified to range picker bottom sheet
- ✅ Removed reciter/translation from favorites
- ✅ All favorites play with default settings

#### 5. Settings Screen ()
- ✅ Clarified as default preferences management
- ✅ Settings apply to new playback sessions only
- ✅ Session changes don't override defaults

## Benefits
- 🚀 **Faster UX**: One-tap to start playing any Surah
- 🎛️ **Flexible**: Easy to customize during playback
- 🎯 **Focused**: Favorites are about Quran portions, not audio configs
- 🔄 **Consistent**: All new sessions use same defaults

## Testing
- [ ] Verify all FRD documents reflect the new flow
- [ ] Confirm user journey is simplified and intuitive
- [ ] Ensure settings behavior is clearly documented